### PR TITLE
Make access of action_name safer

### DIFF
--- a/app/views/rails_admin/main/_dashboard_history.html.haml
+++ b/app/views/rails_admin/main/_dashboard_history.html.haml
@@ -25,4 +25,6 @@
           - label = Object.const_defined?(t.table) ? t.table.constantize.model_name.human : t.table
           %td= "#{label} ##{t.item}"
         %td= t.message
-        %td= link_to(t("admin.history_rollback.table_headers.view_changes"), "#", class: "changeset", :data => {:url => url_for(action: action(:history_index, abstract_model).action_name, model_name: abstract_model.to_param, version_id: t.version_id)})
+        %td
+          -if history_action = action(:history_index, abstract_model)
+            = link_to(t("admin.history_rollback.table_headers.view_changes"), "#", class: "changeset", :data => {:url => url_for(action: history_action.action_name, model_name: abstract_model.to_param, version_id: t.version_id)})


### PR DESCRIPTION
Was seeing an odd issue where `action(:history_index, abstract_model)` was returning nil. This makes sure it doesn't explode when nil is returned.
