### PR TITLE
README: drop unused badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Rails Admin History Rollback
 
 [![Gem Version](https://badge.fury.io/rb/rails_admin_history_rollback.svg)](http://badge.fury.io/rb/rails_admin_history_rollback)
-[![Dependency Status](https://gemnasium.com/rikkipitt/rails_admin_history_rollback.svg)](https://gemnasium.com/rikkipitt/rails_admin_history_rollback)
 [![Code Climate](https://codeclimate.com/github/rikkipitt/rails_admin_history_rollback/badges/gpa.svg)](https://codeclimate.com/github/rikkipitt/rails_admin_history_rollback)
 
 [RailsAdmin](https://github.com/sferik/rails_admin) extension for enabling users to easily visualise and revert their history audit created by the [PaperTrail](https://github.com/airblade/paper_trail) gem.


### PR DESCRIPTION
  - the service is defunct, so this PR removes its badge