### PR TITLE
Fix 'View changes' link just displaying the list of versions again.

### DIFF
--- a/lib/rails_admin_history_rollback/config/actions/history_index.rb
+++ b/lib/rails_admin_history_rollback/config/actions/history_index.rb
@@ -24,7 +24,7 @@ module RailsAdmin
           proc do
             @general = true
             @history = @auditing_adapter && @auditing_adapter.listing_for_model(@abstract_model, params[:query], params[:sort], params[:sort_reverse], params[:all], params[:page]) || []
-            @version = PaperTrail::Version.find(params[:version_id]) if params[:version_id] rescue false
+            @version = ::PaperTrail::Version.find(params[:version_id]) if params[:version_id] rescue false
 
             if request.get? # SHOW
 


### PR DESCRIPTION

![Screenshot from 2021-03-11 11-45-16](https://user-images.githubusercontent.com/593237/110783561-8680ee80-8260-11eb-815e-39d4c87e4344.png)

Turns out the proc which generates the list raises the following error:
NameError Exception: uninitialized constant RailsAdmin::PaperTrail::Version