### PR TITLE
Allow for custom version classes

### DIFF
--- a/lib/rails_admin_history_rollback/config/actions/history_index.rb
+++ b/lib/rails_admin_history_rollback/config/actions/history_index.rb
@@ -24,7 +24,8 @@ module RailsAdmin
           proc do
             @general = true
             @history = @auditing_adapter && @auditing_adapter.listing_for_model(@abstract_model, params[:query], params[:sort], params[:sort_reverse], params[:all], params[:page]) || []
-            @version = ::PaperTrail::Version.find(params[:version_id]) if params[:version_id] rescue false
+            version_class = @abstract_model.model.paper_trail_options.dig(:versions, :class_name).try(:constantize) || ::PaperTrail::Version
+            @version = version_class.find(params[:version_id]) if params[:version_id] rescue false
 
             if request.get? # SHOW
 


### PR DESCRIPTION
Pulling from the current model config (if given), we can fetch the appropriate class to look up version history and default to `PaperTrail::Version` when no class is set on a configured model. The approach here serves as a workaround to avoid calling private or protected methods that are otherwise available:

ie. this effectively copies the [(protected) `version_class_for` method on the adapter in RailsAdmin](https://github.com/sferik/rails_admin/blob/43794519dd011a6db2198c31c6effa48953e5c4d/lib/rails_admin/extensions/paper_trail/auditing_adapter.rb#L154-L156) - which we can't call here without using `#send`

There's also a way of fetching the version class from PaperTrail [here](https://github.com/paper-trail-gem/paper_trail/blob/9e82585c0170f301d4b9aa893b889c2faabcbadf/lib/paper_trail/model_config.rb#L120-L123), however that method is _marked_ as private (though not defined as a private method)

Closes https://github.com/jemcode/rails_admin_history_rollback/issues/23

